### PR TITLE
chore(update): wip - updating to beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,18 @@
   "license": "ISC",
   "devDependencies": {
     "electron": "^0.4.1",
-    "electron-prebuilt": "^0.34.0",
+    "electron-prebuilt": "^0.36.4",
     "typescript": "^1.6.2"
   },
   "dependencies": {
-    "angular2": "^2.0.0-alpha.46",
+    "angular2": "2.0.0-beta.1",
     "css": "^2.2.1",
-    "parse5": "^1.5.0"
+    "es6-promise": "^3.0.2",
+    "es6-shim": "^0.33.3",
+    "parse5": "^1.5.0",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "5.0.0-beta.0",
+    "systemjs": "^0.19.17",
+    "zone.js": "0.5.10"
   }
 }

--- a/src/components/ElectronApp.ts
+++ b/src/components/ElectronApp.ts
@@ -1,7 +1,8 @@
 declare var Notification;
 
 import {SampleService} from '../services/SampleService';
-import {Component, Control} from 'angular2/angular2';
+import {Component} from 'angular2/core';
+import {FORM_DIRECTIVES, Control} from 'angular2/common';
 
 @Component({
   selector: 'app',
@@ -11,11 +12,12 @@ import {Component, Control} from 'angular2/angular2';
     <form>
       <div class="form-group">
       <label>Enter Your Name</label>
-      <input type="text" class="form-control" placeholder="Your Name Here" [ng-form-control]="nameInput">
+      <input type="text" class="form-control" placeholder="Your Name Here" [ngFormControl]="nameInput">
     </form>
   </div>
   `,
-  providers: [SampleService]
+  providers: [SampleService],
+  directives: [FORM_DIRECTIVES]
 })
 export class ElectronApp {
   name:string = '';

--- a/src/main.html
+++ b/src/main.html
@@ -6,10 +6,14 @@
   <body>
     <div class="window">
       <div class="window-content">
-        <app></app>
+        <app>Loading...</app>
       </div>
     </div>
     
+    <script src="../node_modules/angular2/bundles/angular2-polyfills.js"></script>
+    <script src="../node_modules/systemjs/dist/system.src.js"></script>
+    <script src="../node_modules/angular2/bundles/web_worker/ui.dev.js"></script>
+    <script src="../node_modules/angular2/bundles/web_worker/worker.dev.js"></script>
     <script>
       require('./main.js');
     </script>

--- a/src/ng_electron/electron_message_bus.ts
+++ b/src/ng_electron/electron_message_bus.ts
@@ -1,6 +1,3 @@
-declare var require;
-const ipc = require('ipc');
-
 import {
   MessageBus,
   MessageBusSource,

--- a/src/ng_electron/server.ts
+++ b/src/ng_electron/server.ts
@@ -1,10 +1,18 @@
 import 'zone.js/dist/zone-microtask';
 import 'reflect-metadata';
 import {
-  bootstrapWebWorkerCommon
-} from 'angular2/src/web_workers/worker/application_common';
-import {createNgZone, NgZone, Injector} from 'angular2/core';
-import {Parse5DomAdapter} from 'angular2/src/core/dom/parse5_adapter';
+  initializeGenericWorkerRenderer,
+  MessageBus
+} from 'angular2/platform/worker_render';
+import {
+  WORKER_APP_APPLICATION
+} from "angular2/platform/worker_app";
+import {
+  WORKER_APP_PLATFORM,
+  WORKER_APP_APPLICATION_COMMON
+} from 'angular2/src/platform/worker_app_common';
+import {NgZone, platform, Provider, APP_INITIALIZER} from 'angular2/core';
+import {Parse5DomAdapter} from 'angular2/src/platform/server/parse5_adapter';
 import {
   ElectronMessageBus,
   ElectronMessageBusSink,
@@ -17,6 +25,8 @@ const electronApp = require('app');
 const BrowserWindow = require('browser-window');
 const Menu = require('menu');
 const ipc = require('ipc');
+// const ipcMain = require('electron').ipcMain;
+// const ipcRenderer = require('electron').ipcRenderer;
 
 let appWindow;
 
@@ -24,21 +34,32 @@ const loadAndWait = (path, options) => new Promise((resolve, reject) => {
   appWindow = new BrowserWindow({width : 800, height : 600});
   ipc.on('__ngBootstrap', () => { resolve(appWindow); });
   // TODO: fix this
-  appWindow.loadUrl(`file://${__dirname}/../main.html`);
+  appWindow.loadURL(`file://${__dirname}/../main.html`);
 });
 
 const appReady = new Promise(resolve => { electronApp.on('ready', resolve); });
 
-const bootstrapElectronAngular = (comType, bindings) => (appWindow) => {
+const bootstrapElectronAngular = (compType, bindings) => (appWindow) => {
 
   const messageSink = new ElectronMessageBusSink(appWindow.webContents);
   const messageSource = new ElectronMessageBusSource(ipc);
 
   const messageBus = new ElectronMessageBus(messageSink, messageSource, ELECTRON_WORKER);
+  
+  return platform([WORKER_APP_PLATFORM, bindings])
+    .application([
+      WORKER_APP_APPLICATION,
+      WORKER_APP_APPLICATION_COMMON,
+      new Provider(MessageBus, { useValue: messageBus }),
+      new Provider(APP_INITIALIZER, {
+        useFactory: (zone, bus) => () => initAppThread(zone, messageBus), multi: true,
+        deps: [NgZone, MessageBus]
+      })])
+      .bootstrap(compType);
+}
 
+const initAppThread = (zone: NgZone, bus: ElectronMessageBus) => {
   Parse5DomAdapter.makeCurrent();
-
-  return bootstrapWebWorkerCommon(comType, messageBus, bindings);
 }
 
 export const bootstrap = (componentRef: any, bindings?: any[]) => {

--- a/src/ng_electron/ui.ts
+++ b/src/ng_electron/ui.ts
@@ -1,8 +1,18 @@
 // electron IPC module
 const ipc = require('ipc');
+// const ipcMain = require('electron').ipcMain;
+// const ipcRenderer = require('electron').ipcRenderer;
 import 'reflect-metadata';
 
-import {bootstrapUICommon} from 'angular2/src/web_workers/ui/impl';
+import {platform, Provider, APP_INITIALIZER, Injector} from 'angular2/core';
+import {
+  WORKER_RENDER_PLATFORM,
+  WORKER_RENDER_APP,
+  initializeGenericWorkerRenderer,
+  MessageBus,
+  WORKER_SCRIPT
+} from 'angular2/platform/worker_render';
+import {WORKER_RENDER_APP_COMMON} from 'angular2/src/platform/worker_render_common';
 import {
   ElectronMessageBus,
   ElectronMessageBusSink,
@@ -12,6 +22,17 @@ import {
 export const bootstrap = () => {
   var bus = new ElectronMessageBus(new ElectronMessageBusSink(ipc),
                                    new ElectronMessageBusSource(ipc))
-      bootstrapUICommon(bus);
+  platform([WORKER_RENDER_PLATFORM])
+    .application([
+      WORKER_RENDER_APP,
+      WORKER_RENDER_APP_COMMON,
+      new Provider(WORKER_SCRIPT, {useValue: "worker.js"}),
+      new Provider(MessageBus, { useValue: bus }),
+      new Provider(APP_INITIALIZER, {
+        useFactory: (injector) => () => initializeGenericWorkerRenderer(injector),
+        deps: [Injector],
+        multi: true
+      })
+    ]);
   ipc.send('__ngBootstrap', 'ready');
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,6 +5,4 @@ import {bootstrap} from './ng_electron/server';
 //sample component
 import {ElectronApp} from './components/ElectronApp';
 
-
 bootstrap(ElectronApp);
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,15 @@
         "outDir": "dist",
         "moduleResolution": "node"
     },
+    "files": [
+        "src/main.ts",
+        "src/worker.ts",
+        "src/components/ElectronApp.ts",
+        "src/ng_electron/electron_message_bus.ts",
+        "src/ng_electron/server.ts",
+        "src/ng_electron/ui.ts",
+        "src/services/SampleService.ts"
+    ],
     "exclude": [
         "node_modules"
     ]


### PR DESCRIPTION
This is an attempt to update to beta.1 and use SystemJS. It's close (so **WIP**) but stumped on some SystemJS config settings. @robwormald You may know exactly what this is if you get a minute to pull this branch and have a quick look.

I used these as references:
https://github.com/angular/angular/blob/master/modules/angular2/docs/web_workers/web_workers.md
https://github.com/jteplitz602/ng2_web_worker_starter_pack

Electron's api changes:

```
const ipcMain = require('electron').ipcMain;
const ipcRenderer = require('electron').ipcRenderer;
```

See section `Splitting the ipc module`: http://blog.atom.io/2015/11/17/electron-api-changes.html

However, I could not get those to work initially; the html would never load in the webview at all. Furthermore, an issue was reported about the `ipcRenderer` being `undefined` (which I also experienced) and keep this in mind:
https://github.com/atom/electron/issues/4081

> The npm electron module conflicts with electron's built-in module, if you want to use the npm module you have to use require('ipc-renderer') instead of require('electron').ipcRenderer.

Using `ipc` as you were doing currently appears to still work. 
Would be great to get your help as I'm trying to setup an advanced angular2 seed which would utilize an Electron setup in addition to more:
https://github.com/mgechev/angular2-seed/issues/398
